### PR TITLE
Changed MinifierFactory::create() to static

### DIFF
--- a/src/MinifierFactory.php
+++ b/src/MinifierFactory.php
@@ -8,7 +8,7 @@ use PhpCodeMinifier\Validator\PhpFileValidator;
 
 class MinifierFactory
 {
-    public function create(): PhpMinifier
+    public static function create(): PhpMinifier
     {
         return new PhpMinifier(
             new PhpFileValidator(),


### PR DESCRIPTION
Currently you need to instantiate the MinifierFactory to use it:
```php
$minifier = (new MinifierFactory())->create();
```

The method is now static to follow the documentation.
```php
<?php

// Create a new instance of minifier via the factory
$phpCodeMinifier = \PhpCodeMinifier\MinifierFactory::create();
```