### PR TITLE
Added support for heredoc with double quotes statements.

### DIFF
--- a/src/PhpMinifier.php
+++ b/src/PhpMinifier.php
@@ -155,8 +155,8 @@ class PhpMinifier
         $str = '';
         while (['token' => $token] = array_shift($tokens)) {
             if (str_starts_with($token, '<<<')) {
-                if (str_starts_with($token, '<<<\'')) {
-                    // Nowdoc identifier
+                if (str_starts_with($token, '<<<\'') || str_starts_with($token, '<<<"')) {
+                    // Nowdoc and heredoc with double quote identifier
                     $identifier = substr($token, 4, -1);
                 } else {
                     // Heredoc identifier

--- a/tests/Fixtures/ActualFiles/heredoc-nowdoc.php
+++ b/tests/Fixtures/ActualFiles/heredoc-nowdoc.php
@@ -1,5 +1,10 @@
 <?php
 
+echo <<<"EOF"
+hello!
+how's it going?
+EOF;
+
 echo <<<EOF
 hello!
 how's it going?

--- a/tests/Fixtures/Expected/heredoc-nowdoc.php
+++ b/tests/Fixtures/Expected/heredoc-nowdoc.php
@@ -1,4 +1,7 @@
-<?php echo <<<EOF
+<?php echo <<<"EOF"
+hello!
+how's it going?
+EOF;echo <<<EOF
 hello!
 how's it going?
 EOF;function test():string{return <<<'PHP'


### PR DESCRIPTION
According to php docs - https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc:
> The opening Heredoc identifier may optionally be enclosed in double quotes